### PR TITLE
Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: python
 python:
   - "2.7"
-
+  - "3.4"
 notifications:
     email: false
 
 # Setup anaconda to get scipy, and others
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
@@ -19,7 +23,7 @@ before_install:
 
 # Install packages
 install:
-  - conda create -n testenv pip python=2.7
+  - conda create -n testenv pip python=$TRAVIS_PYTHON_VERSION
   - conda update conda
   - source activate testenv
   - conda install --file requirements.txt

--- a/pacpy/__init__.py
+++ b/pacpy/__init__.py
@@ -1,3 +1,5 @@
-import pac
-import filt
-import util
+from __future__ import absolute_import
+
+from . import pac
+from . import filt
+from . import util

--- a/pacpy/pac.py
+++ b/pacpy/pac.py
@@ -7,7 +7,6 @@ import numpy as np
 from scipy.signal import hilbert
 from scipy.stats.mstats import zscore
 from pacpy.filt import firf, morletT
-import statsmodels.api as sm
 
 
 def _x_sanity(lo=None, hi=None):


### PR DESCRIPTION
This small PR:
- changes imports in `__init__.py` so that `pacpy` works well on python 3
- makes travis test `pacpy` on python 3 as well