### PR TITLE
cast N as an integer in _remove_edge

### DIFF
--- a/pacpy/filt.py
+++ b/pacpy/filt.py
@@ -192,4 +192,5 @@ def _remove_edge(x, N):
     N : int
         length of filter
     """
+    N = int(N)
     return x[N:-N]


### PR DESCRIPTION
This is throwing a DeprecationWarning when a float is provided